### PR TITLE
Fix crash with only one datapoint where 'x' is 0

### DIFF
--- a/lib/sparkline_svg/core.ex
+++ b/lib/sparkline_svg/core.ex
@@ -44,7 +44,12 @@ defmodule SparklineSvg.Core do
     {{_, min_y}, {_, max_y}} = Enum.min_max_by(datapoints, fn {_, y} -> y end)
     [{x, y} | _tail] = datapoints
 
-    min_max_x = if max_x - min_x == 0, do: {0, 2 * x}, else: {min_x, max_x}
+    min_max_x =
+      cond do
+        max_x - min_x != 0 -> {min_x, max_x}
+        x == 0 -> {-1, 1}
+        true -> {0, 2 * x}
+      end
 
     min_max_y =
       cond do

--- a/test/sparkline_svg_test.exs
+++ b/test/sparkline_svg_test.exs
@@ -104,6 +104,14 @@ defmodule SparklineSvgTest do
     assert sparkline.datapoints == [{2.0, 25.0}, {198.0, 25.0}]
   end
 
+  test "with one value datapoints" do
+    {:ok, sparkline} = SparklineSvg.new([1]) |> SparklineSvg.dry_run()
+    assert sparkline.datapoints == [{100.0, 25.0}]
+
+    {:ok, sparkline} = SparklineSvg.new([{5, 1}]) |> SparklineSvg.dry_run()
+    assert sparkline.datapoints == [{100.0, 25.0}]
+  end
+
   test "to_svg!/1 error handling" do
     assert_raise SparklineSvg.Error, "invalid_x_type", fn ->
       SparklineSvg.new([{"a", 1}, {"b", 2}]) |> SparklineSvg.to_svg!()


### PR DESCRIPTION
Fix #31.