### PR TITLE
Add window

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,14 @@ Markers are used to highlight specific spots on the chart. There are two types o
 ### Reference lines
 
 Reference lines are used to show common reference lines on the chart. There are four types of
-currently supported reference lines (`maximum`, `minimum`, `average`, and `median`) that will
-be rendered as horizontal lines.
+currently supported reference lines (`maximum`, `minimum`, `average`, `median`, and `percentile/1`)
+that will be rendered as horizontal lines.
+
+## Window
+
+Normally the window is automatically calculated based on the datapoints. However, you can set the
+min or the max value of the window or both to show only a specific part of the chart or to always
+display the same amount of data.
 
 ### Customization
 

--- a/lib/sparkline_svg.ex
+++ b/lib/sparkline_svg.ex
@@ -129,7 +129,14 @@ defmodule SparklineSvg do
 
   ## Window
 
-  TODO.
+  Window option can be used to set the minimum and maximum value of the x axis of the chart.
+  Normally the window is automatically calculated based on the datapoints. You can set the min or
+  the max value of the window or both.
+
+  Outside of window datapoints will be discarded before calculation of the reference lines.
+
+  This can be useful to have a consistent chart when the data is not consistent or to have multiple
+  charts with the same window.
 
   ## Customization
 
@@ -252,7 +259,10 @@ defmodule SparklineSvg do
 
   ### Window options
 
-  TODO.
+  - `:min` - the minimum value of the window, defaults to `:auto`. The value must be of the same
+    type as the `x` axis of the chart, or `:auto`.
+  - `:max` - the maximum value of the window, defaults to `:auto`. The value must be of the same
+    type as the `x` axis of the chart, or `:auto`.
 
   """
 

--- a/lib/sparkline_svg.ex
+++ b/lib/sparkline_svg.ex
@@ -127,6 +127,10 @@ defmodule SparklineSvg do
 
   See the documentation of `m:SparklineSvg.ReferenceLine` for more information on how to use.
 
+  ## Window
+
+  TODO.
+
   ## Customization
 
   SparklineSvg allows you to customize the chart showing or hiding the dots, the line, and the area
@@ -245,6 +249,10 @@ defmodule SparklineSvg do
     to `""`. Valid dasharray values can be found
     [here](https://developer.mozilla.org/en-US/docs/Web/SVG/attributee/stroke-dasharray).
   - `:class` - the value of the HTML class attribute of the reference line, defaults to `nil`.
+
+  ### Window options
+
+  TODO.
 
   """
 
@@ -542,6 +550,7 @@ defmodule SparklineSvg do
       iex> chart = SparklineSvg.new([1, 2]) |> SparklineSvg.show_ref_line(:avg, color: "red")
       iex> SparklineSvg.to_svg!(chart)
       ~S'<svg width="100%" height="100%" viewBox="0 0 200 50" xmlns="http://www.w3.org/2000/svg"><line x1="2" y1="25.0" x2="198" y2="25.0" fill="none" stroke="red" stroke-width="0.25" /></svg>'
+
   """
 
   @doc since: "0.2.0"
@@ -555,12 +564,40 @@ defmodule SparklineSvg do
   end
 
   @doc ~S"""
-  TODO.
+  Set the x window of a sparkline struct with the given options.
+
+  The window is automatically calculated based on the datapoints. If you want to set a custom
+  window, use this function.
+
+  Datapoints outside the window will be removed before rendering and reference lines computations.
+
+  When using this function with a list of numbers as datapoints, the min window value and the max
+  window must be interpreted as the index of the list. Negative values are allowed.
+
+  ## Examples
+
+      iex> chart = SparklineSvg.new([1, 2, 3, 4]) |> SparklineSvg.show_line() |> SparklineSvg.set_x_window(min: 1, max: 2)
+      iex> SparklineSvg.to_svg!(chart)
+      ~S'<svg width="100%" height="100%" viewBox="0 0 200 50" xmlns="http://www.w3.org/2000/svg"><path d="M2.0,48.0C31.4,41.1 168.6,8.9 198.0,2.0" fill="none" stroke="black" stroke-width="0.25" /></svg>'
+
+      iex> chart = SparklineSvg.new([1, 2, 3]) |> SparklineSvg.show_line() |> SparklineSvg.set_x_window(min: -1, max: 3)
+      iex> SparklineSvg.to_svg!(chart)
+      ~S'<svg width="100%" height="100%" viewBox="0 0 200 50" xmlns="http://www.w3.org/2000/svg"><path d="M51.0,48.0C58.35,44.55 85.3,31.9 100.0,25.0C114.7,18.1 141.65,5.45 149.0,2.0" fill="none" stroke="black" stroke-width="0.25" /></svg>'
+
+      iex> now = DateTime.utc_now()
+      iex> chart =
+      ...>   [{now, 2}, {DateTime.add(now, 1), 3}]
+      ...>   |> SparklineSvg.new()
+      ...>   |> SparklineSvg.show_line()
+      ...>   |> SparklineSvg.set_x_window(min: DateTime.add(now, -1))
+      iex> SparklineSvg.to_svg!(chart)
+      ~S'<svg width="100%" height="100%" viewBox="0 0 200 50" xmlns="http://www.w3.org/2000/svg"><path d="M100.0,48.0C114.7,41.1 183.3,8.9 198.0,2.0" fill="none" stroke="black" stroke-width="0.25" /></svg>'
+
   """
 
   @default_window_opts [min: :auto, max: :auto]
 
-  @doc since: "0.4.0"
+  @doc since: "0.5.0"
   @spec set_x_window(t()) :: t()
   @spec set_x_window(t(), window_options()) :: t()
   def set_x_window(sparkline, options \\ []) do

--- a/lib/sparkline_svg/core.ex
+++ b/lib/sparkline_svg/core.ex
@@ -29,12 +29,21 @@ defmodule SparklineSvg.Core do
   end
 
   def compute(%SparklineSvg{} = sparkline) do
-    %{datapoints: datapoints, ref_lines: ref_lines, markers: markers, options: options} =
+    %{
+      datapoints: datapoints,
+      ref_lines: ref_lines,
+      markers: markers,
+      options: options,
+      window: window
+    } =
       sparkline
 
-    # fetch min and max values from the options
-    # if not present, calculate them from the datapoints
-    {min_max_x, min_max_y} = get_min_max(datapoints)
+    {{min_x, max_x}, min_max_y} = get_min_max(datapoints)
+
+    min_x = if window.min == :auto, do: min_x, else: window.min
+    max_x = if window.max == :auto, do: max_x, else: window.max
+
+    min_max_x = {min_x, max_x}
 
     %SparklineSvg{
       sparkline

--- a/lib/sparkline_svg/core.ex
+++ b/lib/sparkline_svg/core.ex
@@ -32,6 +32,8 @@ defmodule SparklineSvg.Core do
     %{datapoints: datapoints, ref_lines: ref_lines, markers: markers, options: options} =
       sparkline
 
+    # fetch min and max values from the options
+    # if not present, calculate them from the datapoints
     {min_max_x, min_max_y} = get_min_max(datapoints)
 
     %SparklineSvg{

--- a/lib/sparkline_svg/core.ex
+++ b/lib/sparkline_svg/core.ex
@@ -35,8 +35,7 @@ defmodule SparklineSvg.Core do
       markers: markers,
       options: options,
       window: window
-    } =
-      sparkline
+    } = sparkline
 
     {{min_x, max_x}, min_max_y} = get_min_max(datapoints)
 

--- a/lib/sparkline_svg/datapoint.ex
+++ b/lib/sparkline_svg/datapoint.ex
@@ -21,20 +21,18 @@ defmodule SparklineSvg.Datapoint do
           {:halt, {{:error, :mixed_datapoints_types}, type}}
       end)
 
-    case datapoints do
-      {:error, reason} ->
-        {:error, reason}
+    with datapoints when is_list(datapoints) <- datapoints,
+         {:ok, min, _type} <- Type.cast_window(window.min, type),
+         {:ok, max, _type} <- Type.cast_window(window.max, type) do
+      window = %{min: min, max: max}
 
-      datapoints ->
-        # check for window type (current type or auto)
+      datapoints =
+        datapoints
+        |> Enum.uniq_by(fn {x, _} -> x end)
+        |> Enum.sort_by(fn {x, _} -> x end)
+        |> window(window)
 
-        datapoints =
-          datapoints
-          |> Enum.uniq_by(fn {x, _} -> x end)
-          |> Enum.sort_by(fn {x, _} -> x end)
-          |> window(window)
-
-        {:ok, datapoints, window, type}
+      {:ok, datapoints, window, type}
     end
   end
 
@@ -53,19 +51,17 @@ defmodule SparklineSvg.Datapoint do
           end
       end)
 
-    case datapoints do
-      {:error, reason} ->
-        {:error, reason}
+    with datapoints when is_list(datapoints) <- datapoints,
+         {:ok, min, _type} <- Type.cast_window(window.min, :number),
+         {:ok, max, _type} <- Type.cast_window(window.max, :number) do
+      window = %{min: min, max: max}
 
-      datapoints ->
-        # check for window type (type or auto)
+      datapoints =
+        datapoints
+        |> Enum.reverse()
+        |> window(window)
 
-        datapoints =
-          datapoints
-          |> Enum.reverse()
-          |> window(window)
-
-        {:ok, datapoints, window, :number}
+      {:ok, datapoints, window, :number}
     end
   end
 

--- a/lib/sparkline_svg/type.ex
+++ b/lib/sparkline_svg/type.ex
@@ -48,13 +48,16 @@ defmodule SparklineSvg.Type do
     {:error, :invalid_y_type}
   end
 
-  @spec cast_window(:auto | SparklineSvg.x(), atom()) ::
-          {:ok, :auto | Core.x(), atom()} | {:error, atom()}
-  def cast_window(:auto, type) do
-    {:ok, :auto, type}
+  @spec cast_window(:auto | SparklineSvg.x(), Core.x()) ::
+          {:ok, :auto | Core.x()} | {:error, atom()}
+  def cast_window(:auto, _type) do
+    {:ok, :auto}
   end
 
   def cast_window(x, type) do
-    cast_x(x, type)
+    case cast_x(x, type) do
+      {:ok, x, _type} -> {:ok, x}
+      {:error, reason} -> {:error, reason}
+    end
   end
 end

--- a/lib/sparkline_svg/type.ex
+++ b/lib/sparkline_svg/type.ex
@@ -47,4 +47,14 @@ defmodule SparklineSvg.Type do
   def cast_y(_y) do
     {:error, :invalid_y_type}
   end
+
+  @spec cast_window(:auto | SparklineSvg.x(), atom()) ::
+          {:ok, :auto | Core.x(), atom()} | {:error, atom()}
+  def cast_window(:auto, type) do
+    {:ok, :auto, type}
+  end
+
+  def cast_window(x, type) do
+    cast_x(x, type)
+  end
 end

--- a/test/sparkline_svg_window_test.exs
+++ b/test/sparkline_svg_window_test.exs
@@ -1,9 +1,9 @@
 defmodule SparklineSvgWindowTest do
   use ExUnit.Case, async: true
 
-  test "todo1" do
+  test "set_x_window/2 with too much data" do
     {:ok, sparkline} =
-      [{0, 2}, {1, 2}, {2, 2}]
+      [2, 2, 2]
       |> SparklineSvg.new()
       |> SparklineSvg.set_x_window(min: 1)
       |> SparklineSvg.dry_run()
@@ -13,9 +13,47 @@ defmodule SparklineSvgWindowTest do
     {:ok, sparkline} =
       [2, 2, 2]
       |> SparklineSvg.new()
-      |> SparklineSvg.set_x_window(min: 1)
+      |> SparklineSvg.set_x_window(max: 1)
       |> SparklineSvg.dry_run()
 
     assert sparkline.datapoints == [{2.0, 25.0}, {198.0, 25.0}]
+
+    {:ok, sparkline} =
+      [2, 2, 2, 2, 2, 2, 2]
+      |> SparklineSvg.new()
+      |> SparklineSvg.set_x_window(min: 1, max: 2)
+      |> SparklineSvg.dry_run()
+
+    assert sparkline.datapoints == [{2.0, 25.0}, {198.0, 25.0}]
+  end
+
+  test "set_x_window/2 with {x, y} data" do
+    {:ok, sparkline} =
+      [{1, 2}, {2, 2}, {3, 2}]
+      |> SparklineSvg.new()
+      |> SparklineSvg.set_x_window(min: 2)
+      |> SparklineSvg.dry_run()
+
+    assert sparkline.datapoints == [{2.0, 25.0}, {198.0, 25.0}]
+  end
+
+  test "set_x_window/2 with hole on left" do
+    {:ok, sparkline} =
+      [2, 2]
+      |> SparklineSvg.new()
+      |> SparklineSvg.set_x_window(min: -1)
+      |> SparklineSvg.dry_run()
+
+    assert sparkline.datapoints == [{100.0, 25.0}, {198.0, 25.0}]
+  end
+
+  test "set_x_window/2 with hole on right" do
+    {:ok, sparkline} =
+      [2, 2]
+      |> SparklineSvg.new()
+      |> SparklineSvg.set_x_window(max: 2)
+      |> SparklineSvg.dry_run()
+
+    assert sparkline.datapoints == [{2.0, 25.0}, {100.0, 25.0}]
   end
 end

--- a/test/sparkline_svg_window_test.exs
+++ b/test/sparkline_svg_window_test.exs
@@ -80,4 +80,14 @@ defmodule SparklineSvgWindowTest do
 
     assert resp == {:error, :mixed_datapoints_types}
   end
+
+  test "set_x_window/2 out-of-bound" do
+    {:ok, sparkline} =
+      1..5
+      |> SparklineSvg.new()
+      |> SparklineSvg.set_x_window(min: -5, max: -1)
+      |> SparklineSvg.dry_run()
+
+    assert sparkline.datapoints == []
+  end
 end

--- a/test/sparkline_svg_window_test.exs
+++ b/test/sparkline_svg_window_test.exs
@@ -1,0 +1,21 @@
+defmodule SparklineSvgWindowTest do
+  use ExUnit.Case, async: true
+
+  test "todo1" do
+    {:ok, sparkline} =
+      [{0, 2}, {1, 2}, {2, 2}]
+      |> SparklineSvg.new()
+      |> SparklineSvg.set_x_window(min: 1)
+      |> SparklineSvg.dry_run()
+
+    assert sparkline.datapoints == [{2.0, 25.0}, {198.0, 25.0}]
+
+    {:ok, sparkline} =
+      [2, 2, 2]
+      |> SparklineSvg.new()
+      |> SparklineSvg.set_x_window(min: 1)
+      |> SparklineSvg.dry_run()
+
+    assert sparkline.datapoints == [{2.0, 25.0}, {198.0, 25.0}]
+  end
+end

--- a/test/sparkline_svg_window_test.exs
+++ b/test/sparkline_svg_window_test.exs
@@ -56,4 +56,28 @@ defmodule SparklineSvgWindowTest do
 
     assert sparkline.datapoints == [{2.0, 25.0}, {100.0, 25.0}]
   end
+
+  test "set_x_window/2 with non-number window" do
+    now = DateTime.utc_now()
+
+    {:ok, sparkline} =
+      [{now, 1}, {DateTime.add(now, 1), 2}]
+      |> SparklineSvg.new()
+      |> SparklineSvg.set_x_window(min: DateTime.add(now, -1))
+      |> SparklineSvg.dry_run()
+
+    assert sparkline.datapoints == [{100.0, 48.0}, {198.0, 2.0}]
+  end
+
+  test "set_x_window/2 with mixed data type" do
+    now = DateTime.utc_now()
+
+    resp =
+      [{now, 1}, {DateTime.add(now, 1), 2}]
+      |> SparklineSvg.new()
+      |> SparklineSvg.set_x_window(min: Time.utc_now())
+      |> SparklineSvg.dry_run()
+
+    assert resp == {:error, :mixed_datapoints_types}
+  end
 end


### PR DESCRIPTION
Add window configuration. Allows to set a min `x` value, a max `x` value, or both. A custom window will either filter out some datapoints outside the window or set a "hole" on the left or the right (or both) of the rendered graph.

- [x] Add set_x_window/2
- [x] Add related tests
- [x] Add related documentation