### PR TITLE
Expose precision

### DIFF
--- a/lib/sparkline_svg.ex
+++ b/lib/sparkline_svg.ex
@@ -207,6 +207,9 @@ defmodule SparklineSvg do
     + bottom_padding < height` otherwise a `:invalid_dimension` error will be raised.
   - `:smoothing` - the smoothing of the line (`0` = no smoothing, above `0.4` it becomes
     unreadable), defaults to `0.15`. Not targetable with CSS classes.
+  - `:precision` - the maximum precision of the values used to render the chart, defaults to `3`.
+    Not targetable with CSS classes. The precision can be set between `0` and `15`. The greater the
+    precision, the more accurate the chart will be but the heavier the SVG will be.
   - `:placeholder` - a placeholder for an empty chart, defaults to `nil`. If set to `nil`, a chart
     with no datapoints will be an empty SVG document. Alternatively, you can set it to a string to
     display a message when the chart is empty. Not targetable with CSS classes.

--- a/lib/sparkline_svg.ex
+++ b/lib/sparkline_svg.ex
@@ -315,6 +315,7 @@ defmodule SparklineSvg do
             | {:height, number()}
             | {:padding, padding()}
             | {:smoothing, number()}
+            | {:precision, non_neg_integer()}
             | {:placeholder, nil | String.t()}
             | {:class, nil | String.t()}
             | {:placeholder_class, nil | String.t()}
@@ -402,6 +403,7 @@ defmodule SparklineSvg do
     height: 50,
     padding: 2,
     smoothing: 0.15,
+    precision: 3,
     placeholder: nil,
     class: nil,
     placeholder_class: nil

--- a/lib/sparkline_svg/draw.ex
+++ b/lib/sparkline_svg/draw.ex
@@ -66,7 +66,15 @@ defmodule SparklineSvg.Draw do
         else: [~s'class="', class, ~s'"']
 
     Enum.map(datapoints, fn {x, y} ->
-      [~s'<circle cx="', cast(x), ~s'" cy="', cast(y), ~s'" r="#{radius}" ', attrs, ~s' />']
+      [
+        ~s'<circle cx="',
+        cast(x, options),
+        ~s'" cy="',
+        cast(y, options),
+        ~s'" r="#{radius}" ',
+        attrs,
+        ~s' />'
+      ]
     end)
   end
 
@@ -87,7 +95,7 @@ defmodule SparklineSvg.Draw do
         [~s'class="', class, ~s'"']
       end
 
-    path = ["M#{left},", cast(y), "L#{right},", cast(y)]
+    path = ["M#{left},", cast(y, options), "L#{right},", cast(y, options)]
     [~s'<path d="', path, ~s'" ', attrs, ~s' />']
   end
 
@@ -145,9 +153,9 @@ defmodule SparklineSvg.Draw do
 
     [
       ~s'<rect x="',
-      cast(min(x1, x2)),
+      cast(min(x1, x2), options),
       ~s'" y="#{-width}" width="',
-      cast(abs(x2 - x1)),
+      cast(abs(x2 - x1), options),
       ~s'" height="#{height + 2 * width}" ',
       attrs,
       ~s' />'
@@ -175,7 +183,7 @@ defmodule SparklineSvg.Draw do
         [~s'class="', class, ~s'"']
       end
 
-    [~s'<path d="M', cast({x, 0.0}), ~s'V#{height}" ', attrs, ~s' />']
+    [~s'<path d="M', cast({x, 0.0}, options), ~s'V#{height}" ', attrs, ~s' />']
   end
 
   @spec ref_lines(SparklineSvg.ref_lines(), SparklineSvg.opts()) :: iolist()
@@ -189,7 +197,7 @@ defmodule SparklineSvg.Draw do
       ref_line
 
     %{padding: padding, width: graph_width} = options
-    y = cast(y)
+    y = cast(y, options)
 
     attrs =
       if class == nil do
@@ -208,7 +216,7 @@ defmodule SparklineSvg.Draw do
 
   @spec compute_curve(Core.points(), SparklineSvg.opts()) :: iolist()
   defp compute_curve([curr | rest], options) do
-    ["M#{cast(curr)}"]
+    ["M#{cast(curr, options)}"]
     |> compute_curve(rest, curr, curr, options)
   end
 
@@ -241,7 +249,7 @@ defmodule SparklineSvg.Draw do
     cp1 = calculate_control_point(prev1, prev2, curr, :left, options)
     cp2 = calculate_control_point(curr, prev1, next, :right, options)
 
-    [acc, "C", cast(cp1), " ", cast(cp2), " ", cast(curr)]
+    [acc, "C", cast(cp1, options), " ", cast(cp2, options), " ", cast(curr, options)]
   end
 
   @spec calculate_control_point(
@@ -274,18 +282,18 @@ defmodule SparklineSvg.Draw do
     }
   end
 
-  @spec cast(number() | {number(), number()}) :: iolist() | String.t()
-  defp cast({x, y}) do
-    [cast(x), ",", cast(y)]
+  @spec cast(number() | {number(), number()}, SparklineSvg.opts()) :: iolist() | String.t()
+  defp cast({x, y}, opts) do
+    [cast(x, opts), ",", cast(y, opts)]
   end
 
-  defp cast(value) when is_integer(value) do
-    cast(value * 1.0)
+  defp cast(value, _opts) when is_integer(value) do
+    Integer.to_string(value)
   end
 
-  defp cast(value) when is_float(value) do
+  defp cast(value, opts) when is_float(value) do
     value
-    |> Float.round(3)
+    |> Float.round(opts.precision)
     |> Float.to_string()
   end
 end

--- a/test/sparkline_svg_draw_test.exs
+++ b/test/sparkline_svg_draw_test.exs
@@ -189,4 +189,20 @@ defmodule SparklineSvgDrawTest do
            |> SparklineSvg.to_svg!() ==
              ~S'<svg width="100%" height="100%" viewBox="0 0 200 50" xmlns="http://www.w3.org/2000/svg"><path d="M2.0,48.0C11.8,44.55 47.733,31.9 67.333,25.0C86.933,18.1 113.067,-1.45 132.667,2.0C152.267,5.45 188.2,41.1 198.0,48.0" fill="none" stroke="black" stroke-width="0.25" /><line x1="2" y1="2.0" x2="198" y2="2.0" class="sparkline-max" /></svg>'
   end
+
+  test "to_svg!/1 with different precision" do
+    assert SparklineSvg.new([1, 2, 5, 2, 13], width: 13.2, height: 22.9, precision: 5)
+           |> SparklineSvg.show_dots()
+           |> SparklineSvg.show_line()
+           |> SparklineSvg.show_area()
+           |> SparklineSvg.to_svg!() ==
+             ~S'<svg width="100%" height="100%" viewBox="0 0 13.2 22.9" xmlns="http://www.w3.org/2000/svg"><path d="M2.0,20.9C2.345,20.66375 3.61,20.27 4.3,19.325C4.99,18.38 5.91,14.6 6.6,14.6C7.29,14.6 8.21,21.215 8.9,19.325C9.59,17.435 10.855,4.59875 11.2,2.0V22.9H2.0Z" fill="rgba(0, 0, 0, 0.1)" stroke="none" /><path d="M2.0,20.9C2.345,20.66375 3.61,20.27 4.3,19.325C4.99,18.38 5.91,14.6 6.6,14.6C7.29,14.6 8.21,21.215 8.9,19.325C9.59,17.435 10.855,4.59875 11.2,2.0" fill="none" stroke="black" stroke-width="0.25" /><circle cx="2.0" cy="20.9" r="1" fill="black" /><circle cx="4.3" cy="19.325" r="1" fill="black" /><circle cx="6.6" cy="14.6" r="1" fill="black" /><circle cx="8.9" cy="19.325" r="1" fill="black" /><circle cx="11.2" cy="2.0" r="1" fill="black" /></svg>'
+
+    assert SparklineSvg.new([1, 2, 5, 2, 13], width: 13.2, height: 22.9, precision: 0)
+           |> SparklineSvg.show_dots()
+           |> SparklineSvg.show_line()
+           |> SparklineSvg.show_area()
+           |> SparklineSvg.to_svg!() ==
+             ~S'<svg width="100%" height="100%" viewBox="0 0 13.2 22.9" xmlns="http://www.w3.org/2000/svg"><path d="M2.0,21.0C2.0,21.0 4.0,20.0 4.0,19.0C5.0,18.0 6.0,15.0 7.0,15.0C7.0,15.0 8.0,21.0 9.0,19.0C10.0,17.0 11.0,5.0 11.0,2.0V22.9H2.0Z" fill="rgba(0, 0, 0, 0.1)" stroke="none" /><path d="M2.0,21.0C2.0,21.0 4.0,20.0 4.0,19.0C5.0,18.0 6.0,15.0 7.0,15.0C7.0,15.0 8.0,21.0 9.0,19.0C10.0,17.0 11.0,5.0 11.0,2.0" fill="none" stroke="black" stroke-width="0.25" /><circle cx="2.0" cy="21.0" r="1" fill="black" /><circle cx="4.0" cy="19.0" r="1" fill="black" /><circle cx="7.0" cy="15.0" r="1" fill="black" /><circle cx="9.0" cy="19.0" r="1" fill="black" /><circle cx="11.0" cy="2.0" r="1" fill="black" /></svg>'
+  end
 end


### PR DESCRIPTION
Expose number precision through general options.

Add the `:precision` option - the maximum precision of the values used to render the chart, defaults to `3`.

Before that PR the precision was already `3`, but hard-coded. This doesn't break any tests and only expose this value. 