### PR TITLE
Add `:sort` option

### DIFF
--- a/lib/sparkline_svg.ex
+++ b/lib/sparkline_svg.ex
@@ -217,6 +217,10 @@ defmodule SparklineSvg do
   - `:class` - the value of the HTML class attribute of the chart, defaults to `nil`.
   - `:placeholder_class` - the value of the HTML class attribute of the placeholder, defaults to
     `nil`. It is the only way to style the placeholder.
+  - `:sort` - can be one of these atoms: `:asc`, `:desc`, or `none`. Defaults to `:asc`. If set to
+    `:asc` or `:desc`, the datapoints will be sorted by the `x` axis before rendering the chart.
+    If set to `:none`, the datapoints will be rendered in the order they are given, potentially
+    resulting in unexpected visual representations.
 
   ### Dots options
 
@@ -319,6 +323,9 @@ defmodule SparklineSvg do
           number()
           | list({:top, number()} | {:right, number()} | {:bottom, number()} | {:left, number()})
 
+  @typedoc "Sorting options for the chart."
+  @type sort_options :: :asc | :desc | :none
+
   @typedoc "Keyword list of options for the chart."
   @type options ::
           list(
@@ -330,6 +337,7 @@ defmodule SparklineSvg do
             | {:placeholder, nil | String.t()}
             | {:class, nil | String.t()}
             | {:placeholder_class, nil | String.t()}
+            | {:sort, sort_options()}
           )
 
   @typedoc "Keyword list of options for the dots of the chart."
@@ -377,6 +385,7 @@ defmodule SparklineSvg do
           placeholder: nil | String.t(),
           class: nil | String.t(),
           placeholder_class: nil | String.t(),
+          sort: sort_options(),
           dots: nil | map(),
           line: nil | map(),
           area: nil | map()
@@ -425,7 +434,8 @@ defmodule SparklineSvg do
     precision: 3,
     placeholder: nil,
     class: nil,
-    placeholder_class: nil
+    placeholder_class: nil,
+    sort: :asc
   ]
 
   @doc since: "0.1.0"
@@ -755,12 +765,12 @@ defmodule SparklineSvg do
       markers: markers,
       ref_lines: ref_lines,
       window: window,
-      options: %{width: width, height: height, padding: padding}
+      options: %{width: width, height: height, padding: padding, sort: sort}
     } = sparkline
 
     with :ok <- check_x_dimension(width, padding),
          :ok <- check_y_dimension(height, padding),
-         {:ok, datapoints, window, type} <- Datapoint.clean(datapoints, window),
+         {:ok, datapoints, window, type} <- Datapoint.clean(datapoints, window, sort),
          {:ok, markers} <- Marker.clean(markers, type),
          {:ok, ref_lines} <- ReferenceLine.clean(ref_lines) do
       sparkline =

--- a/lib/sparkline_svg/datapoint.ex
+++ b/lib/sparkline_svg/datapoint.ex
@@ -18,7 +18,7 @@ defmodule SparklineSvg.Datapoint do
         datapoints
         |> maybe_window(window)
         |> Enum.uniq_by(fn {x, _} -> x end)
-        |> Enum.sort_by(fn {x, _} -> x end)
+        |> Enum.reverse()
 
       {:ok, datapoints, window, type}
     end

--- a/lib/sparkline_svg/datapoint.ex
+++ b/lib/sparkline_svg/datapoint.ex
@@ -4,9 +4,9 @@ defmodule SparklineSvg.Datapoint do
   alias SparklineSvg.Core
   alias SparklineSvg.Type
 
-  @spec clean(SparklineSvg.datapoints(), SparklineSvg.window()) ::
+  @spec clean(SparklineSvg.datapoints(), SparklineSvg.window(), SparklineSvg.sort_options()) ::
           {:ok, Core.points(), SparklineSvg.window(), SparklineSvg.x()} | {:error, atom()}
-  def clean(datapoints, window) do
+  def clean(datapoints, window, sort) do
     {datapoints, type} = ensure_datapoint_type(datapoints)
 
     with datapoints when is_list(datapoints) <- datapoints,
@@ -18,7 +18,13 @@ defmodule SparklineSvg.Datapoint do
         datapoints
         |> maybe_window(window)
         |> Enum.uniq_by(fn {x, _} -> x end)
-        |> Enum.reverse()
+
+      datapoints =
+        case sort do
+          :asc -> Enum.sort_by(datapoints, fn {x, _} -> x end)
+          :desc -> Enum.sort_by(datapoints, fn {x, _} -> x end, :desc)
+          :none -> Enum.reverse(datapoints)
+        end
 
       {:ok, datapoints, window, type}
     end

--- a/test/sparkline_svg_test.exs
+++ b/test/sparkline_svg_test.exs
@@ -94,10 +94,34 @@ defmodule SparklineSvgTest do
     assert sparkline.datapoints == [{2.0, 48.0}, {198.0, 2.0}]
   end
 
-  test "valid descending order datapoints" do
+  test "valid order datapoints sort asc" do
+    data = [{~D[2021-01-02], 1}, {~D[2021-01-01], 2}]
+    {:ok, sparkline} = SparklineSvg.new(data, sort: :asc) |> SparklineSvg.dry_run()
+    assert sparkline.datapoints == [{2.0, 2.0}, {198.0, 48.0}]
+
+    data = [{~D[2021-01-01], 2}, {~D[2021-01-02], 1}]
+    {:ok, sparkline} = SparklineSvg.new(data, sort: :asc) |> SparklineSvg.dry_run()
+    assert sparkline.datapoints == [{2.0, 2.0}, {198.0, 48.0}]
+  end
+
+  test "valid datapoints with sort desc" do
     data = [{~D[2021-01-02], 1}, {~D[2021-01-01], 2}]
     {:ok, sparkline} = SparklineSvg.new(data, sort: :desc) |> SparklineSvg.dry_run()
     assert sparkline.datapoints == [{2.0, 48.0}, {198.0, 2.0}]
+
+    data = [{~D[2021-01-01], 2}, {~D[2021-01-02], 1}]
+    {:ok, sparkline} = SparklineSvg.new(data, sort: :desc) |> SparklineSvg.dry_run()
+    assert sparkline.datapoints == [{2.0, 48.0}, {198.0, 2.0}]
+  end
+
+  test "valid order datapoints sort none" do
+    data = [{~D[2021-01-02], 1}, {~D[2021-01-01], 2}]
+    {:ok, sparkline} = SparklineSvg.new(data, sort: :none) |> SparklineSvg.dry_run()
+    assert sparkline.datapoints == [{2.0, 48.0}, {198.0, 2.0}]
+
+    data = [{~D[2021-01-01], 2}, {~D[2021-01-02], 1}]
+    {:ok, sparkline} = SparklineSvg.new(data, sort: :none) |> SparklineSvg.dry_run()
+    assert sparkline.datapoints == [{2.0, 2.0}, {198.0, 48.0}]
   end
 
   test "two same points" do

--- a/test/sparkline_svg_test.exs
+++ b/test/sparkline_svg_test.exs
@@ -96,7 +96,7 @@ defmodule SparklineSvgTest do
 
   test "valid descending order datapoints" do
     data = [{~D[2021-01-02], 1}, {~D[2021-01-01], 2}]
-    {:ok, sparkline} = SparklineSvg.new(data) |> SparklineSvg.dry_run()
+    {:ok, sparkline} = SparklineSvg.new(data, sort: :desc) |> SparklineSvg.dry_run()
     assert sparkline.datapoints == [{2.0, 48.0}, {198.0, 2.0}]
   end
 

--- a/test/sparkline_svg_test.exs
+++ b/test/sparkline_svg_test.exs
@@ -94,6 +94,12 @@ defmodule SparklineSvgTest do
     assert sparkline.datapoints == [{2.0, 48.0}, {198.0, 2.0}]
   end
 
+  test "valid descending order datapoints" do
+    data = [{~D[2021-01-02], 1}, {~D[2021-01-01], 2}]
+    {:ok, sparkline} = SparklineSvg.new(data) |> SparklineSvg.dry_run()
+    assert sparkline.datapoints == [{2.0, 48.0}, {198.0, 2.0}]
+  end
+
   test "two same points" do
     {:ok, sparkline} = SparklineSvg.new([{1, 0}, {1, 2}]) |> SparklineSvg.dry_run()
     assert sparkline.datapoints == [{100.0, 25.0}]


### PR DESCRIPTION
Add `:sort` option that allows to control how the sparkline is sorted.

- `:asc` (default) - sort in ascending order, it was already the case.
- `:desc` - sort in descending order.
- `:none` - no sort is performed, the datapoints will be rendered in the order they are given, potentially resulting in unexpected visual representations.

Add
- [x] Corresponding tests
- [x] Corresponding documentation