### PR TITLE
Fix MDN link in sparkline_svg.ex

### DIFF
--- a/lib/sparkline_svg.ex
+++ b/lib/sparkline_svg.ex
@@ -230,7 +230,7 @@ defmodule SparklineSvg do
   - `:color` - the color of the line, defaults to `"black"`.
   - `:dasharray` - the value of the HTML stroke-dasharray attribute of the line, defaults to `""`.
     Valid dasharray values can be found
-    [here](https://developer.mozilla.org/en-US/docs/Web/SVG/attributee/stroke-dasharray).
+    [here](https://developer.mozilla.org/en-US/docs/Web/SVG/attribute/stroke-dasharray).
   - `:class` - the value of the HTML class attribute of the line, defaults to `nil`.
 
   ### Area options
@@ -254,7 +254,7 @@ defmodule SparklineSvg do
   - `:color` - the color of the reference line, defaults to `"rgba(0, 0, 0, 0.5)"`.
   - `:dasharray` - the value of the HTML stroke-dasharray attribute of the reference line, defaults
     to `""`. Valid dasharray values can be found
-    [here](https://developer.mozilla.org/en-US/docs/Web/SVG/attributee/stroke-dasharray).
+    [here](https://developer.mozilla.org/en-US/docs/Web/SVG/attribute/stroke-dasharray).
   - `:class` - the value of the HTML class attribute of the reference line, defaults to `nil`.
 
   ### Window options

--- a/lib/sparkline_svg.ex
+++ b/lib/sparkline_svg.ex
@@ -244,7 +244,7 @@ defmodule SparklineSvg do
   - `:stroke_color` - the stroke color of the marker, defaults to `"red"`.
   - `:stroke_dasharray` - the value of the HTML stroke-dasharray attribute of the marker, defaults
     to `""`. Valid dasharray values can be found
-    [here](https://developer.mozilla.org/en-US/docs/Web/SVG/attributee/stroke-dasharray).
+    [here](https://developer.mozilla.org/en-US/docs/Web/SVG/attribute/stroke-dasharray).
   - `:fill_color` - the fill color of an area marker, defaults to `"rgba(255, 0, 0, 0.1)"`.
   - `:class` - the value of the HTML class attribute of the marker, defaults to `nil`.
 


### PR DESCRIPTION
The stroke-dasharray reference link has a typo and 404's.